### PR TITLE
Use recent items icon supplied from core

### DIFF
--- a/info.xml
+++ b/info.xml
@@ -18,7 +18,7 @@
   <version>1.3</version>
   <develStage>stable</develStage>
   <compatibility>
-    <ver>5.12</ver>
+    <ver>5.49</ver>
   </compatibility>
   <comments>Once installed, click on "Recent" in the menubar to access your recently viewed contacts, activities, contributions, etc.</comments>
   <civix>

--- a/recentmenu.php
+++ b/recentmenu.php
@@ -173,21 +173,6 @@ function recentmenu_civicrm_coreResourceList(&$list, $region) {
 }
 
 function _get_recentmenu_items() {
-  $icons = [
-    'Individual' => 'fa-user',
-    'Household' => 'fa-home',
-    'Organization' => 'fa-building',
-    'Activity' => 'fa-tasks',
-    'Case' => 'fa-folder-open',
-    'Contribution' => 'fa-credit-card',
-    'Grant' => 'fa-money',
-    'Group' => 'fa-users',
-    'Membership' => 'fa-id-badge',
-    'Note' => 'fa-sticky-note',
-    'Participant' => 'fa-ticket',
-    'Pledge' => 'fa-paper-plane',
-    'Relationship' => 'fa-handshake-o',
-  ];
   $recent = CRM_Utils_Recent::get();
   $menu = [
     'label' => E::ts('Recent (%1)', [1 => count($recent)]),
@@ -201,13 +186,15 @@ function _get_recentmenu_items() {
       'url' => $item['url'],
       'name' => 'recent_items_' . $i,
       'attr' => ['title' => $item['type']],
-      'icon' => 'crm-i fa-fw ' . CRM_Utils_Array::value($item['type'], $icons, 'fa-gear'),
-      'child' => [[
-        'label' => E::ts('View'),
-        'attr' => ['title' => E::ts('View %1', [1 => $item['type']])],
-        'url' => $item['url'],
-        'name' => 'recent_items_' . $i . '_view',
-      ]]
+      'icon' => 'crm-i fa-fw ' . ($item['icon'] ?? 'fa-gear'),
+      'child' => [
+        [
+          'label' => E::ts('View'),
+          'attr' => ['title' => E::ts('View %1', [1 => $item['type']])],
+          'url' => $item['url'],
+          'name' => 'recent_items_' . $i . '_view',
+        ],
+      ],
     ];
     if (!empty($item['edit_url'])) {
       $node['child'][] = [


### PR DESCRIPTION
CiviCRM core now supplies an 'icon' for each recent item, so there's no-longer a need to maintain a separate entity/icon list in this extension.

See https://github.com/civicrm/civicrm-core/pull/23094