### PR TITLE
Create real menu item so the position, icon & label can be changed.

### DIFF
--- a/js/recentmenu.js
+++ b/js/recentmenu.js
@@ -1,8 +1,8 @@
 (function($) {
   $(document)
     .on('crmLoad', '#civicrm-menu', function() {
-      if (CRM.vars && CRM.vars.recentmenu && !CRM.menubar.getItem('recent_items')) {
-        CRM.menubar.addItems(-1, null, [CRM.vars.recentmenu]);
+      if (CRM.vars && CRM.vars.recentmenu) {
+        CRM.menubar.updateItem(CRM.vars.recentmenu);
       }
     })
     .ajaxSuccess(function(event, xhr, settings) {

--- a/managed/Navigation_recent_items.mgd.php
+++ b/managed/Navigation_recent_items.mgd.php
@@ -1,0 +1,26 @@
+<?php
+use CRM_Recentmenu_ExtensionUtil as E;
+
+return [
+  [
+    'name' => 'Navigation_recent_items',
+    'entity' => 'Navigation',
+    'cleanup' => 'always',
+    'update' => 'unmodified',
+    'params' => [
+      'version' => 4,
+      'values' => [
+        'label' => E::ts('Recent'),
+        'name' => 'recent_items',
+        'url' => NULL,
+        'icon' => 'crm-i fa-history',
+        'permission' => ['access CiviCRM'],
+        'permission_operator' => '',
+        'is_active' => TRUE,
+        'has_separator' => NULL,
+        'parent_id' => NULL,
+        'domain_id' => 'current_domain',
+      ],
+    ],
+  ],
+];

--- a/recentmenu.php
+++ b/recentmenu.php
@@ -172,12 +172,25 @@ function recentmenu_civicrm_coreResourceList(&$list, $region) {
   }
 }
 
+/**
+ * @return array|NULL
+ */
 function _get_recentmenu_items() {
+  // Lookup existing menu item to get the possibly user-defined label and icon
+  $navigation = \Civi\Api4\Navigation::get(FALSE)
+    ->addWhere('name', '=', 'recent_items')
+    ->addSelect('label', 'icon')
+    ->addWhere('domain_id', '=', 'current_domain')
+    ->execute()->first();
+  if (!$navigation) {
+    // Maybe the managed navigation entity hasn't been reconciled yet, e.g. mid-upgrade
+    return NULL;
+  }
   $recent = \Civi\Api4\RecentItem::get()->execute();
   $menu = [
-    'label' => E::ts('Recent (%1)', [1 => $recent->count()]),
+    'label' => $navigation['label'] . ' (' . $recent->count() . ')',
     'name' => 'recent_items',
-    'icon' => 'crm-i fa-history',
+    'icon' => $navigation['icon'],
     'child' => [],
   ];
   $entityTitles = \Civi\Api4\Entity::get(FALSE)


### PR DESCRIPTION
Uses hook_civicrm_managed to insert a real navigation item, which serves as the base for the recent items menu. It can be repositioned anywhere in the navigation tree, even nested inside another menu.

![image](https://user-images.githubusercontent.com/2874912/162092981-e7a9020e-c81b-4cff-b1d9-fa12bb771161.png)
