### PR TITLE
(1.4) fix fatal error when _get_recentmenu_items returns NULL

### DIFF
--- a/recentmenu.php
+++ b/recentmenu.php
@@ -109,9 +109,12 @@ function recentmenu_civicrm_postProcess($formName, &$form) {
  */
 function recentmenu_civicrm_coreResourceList(&$list, $region) {
   if ($region == 'html-header' && CRM_Core_Permission::check('access CiviCRM')) {
-    Civi::resources()
-      ->addScriptFile('org.civicrm.recentmenu', 'js/recentmenu.js', 0, 'html-header')
-      ->addVars('recentmenu', _get_recentmenu_items());
+    $recentMenuItems = _get_recentmenu_items();
+    if ($recentMenuItems) {
+      Civi::resources()
+        ->addScriptFile('org.civicrm.recentmenu', 'js/recentmenu.js', 0, 'html-header')
+        ->addVars('recentmenu', $recentMenuItems);
+    }
   }
 }
 


### PR DESCRIPTION
This extension passes the return value of `_get_recentmenu_items` to `Civi::resources()->addVars()`.  However, the former is of type `array|NULL` whereas the latter only takes arguments of type `array`.