### PR TITLE
Add shortcut key to open Recent Items menu on right side of window

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,5 @@ The extension is licensed under [AGPL-3.0](LICENSE.txt).
 ## Usage
 
 Once installed, click on "Recent" in the menubar to access your recently viewed contacts, activities, contributions, etc.
+
+You can also use the keyboard shortcut Ctrl+' or Cmd+' to open the menu and move it to the far right side of your browser window, in case you simply want to refer to the recent items without interrupting your workflow.

--- a/js/recentmenu.js
+++ b/js/recentmenu.js
@@ -18,4 +18,57 @@
       // Ignore errors thrown by parseJSON and the menubar
       catch (e) {}
     });
+
+  /**
+   * Toggle the Recent Items menu with Ctrl/Cmd + '.
+   *
+   * Move the menu to the far right of the screen, for usability.
+   */
+  $(document).on('keydown', function(e) {
+    if (e.key === "'" && (e.ctrlKey || e.metaKey) && !e.altKey && CRM.menubar) {
+      e.preventDefault();
+      const recentItems = '#civicrm-menu li[data-name="recent_items"]';
+      const menubarAnchor = document.querySelector(recentItems + ' > a');
+      const submenu = document.querySelector(recentItems + ' > ul');
+      if (!menubarAnchor || !submenu) {
+        return;
+      }
+      if (!CRM.menubar.isOpen('recent_items')) {
+        // Don't use open directly because it pulls focus to the menu.
+        $('#civicrm-menu').smartmenus('itemActivate', $(menubarAnchor));
+        pinRight(menubarAnchor, submenu);
+      }
+      else if (submenu.style.position === 'fixed') {
+        CRM.menubar.close();
+      }
+      else {
+        // Open but not pinned, pin it.
+        pinRight(menubarAnchor, submenu);
+      }
+    }
+  });
+
+  function pinRight(menubarAnchor, submenu) {
+    submenu.style.setProperty('position', 'fixed', 'important');
+    submenu.style.setProperty('left', 'auto', 'important');
+    submenu.style.setProperty('right', '0', 'important');
+    submenu.style.setProperty('top', menubarAnchor.getBoundingClientRect().bottom + 'px', 'important');
+  }
+
+  function unpin(submenu) {
+    ['position', 'left', 'right', 'top'].forEach(function(prop) {
+      submenu.style.removeProperty(prop);
+    });
+  }
+
+  $(document).on('crmLoad', '#civicrm-menu', function() {
+    $(this).on('hide.smapi.recentItemsPin', function(e, hidingSubmenu) {
+      if (hidingSubmenu?.style.position === 'fixed' && hidingSubmenu.parentNode?.getAttribute('data-name') === 'recent_items') {
+        // Wait for closing animation to finish.
+        $(hidingSubmenu).promise().done(function() {
+          unpin(hidingSubmenu);
+        });
+      }
+    });
+  });
 })(CRM.$);

--- a/recentmenu.php
+++ b/recentmenu.php
@@ -130,5 +130,11 @@ function _get_recentmenu_items() {
     }
     $menu['child'][] = $node;
   }
+  $menu['child'][] = [
+    'label' => E::ts("Open/close in sidebar (Ctrl or Cmd + ')"),
+    'url' => NULL,
+    'name' => 'recent_items_open_sidebar',
+    'separator' => 'top',
+  ];
   return $menu;
 }

--- a/templates/CRM/common/accesskeys.extra.hlp
+++ b/templates/CRM/common/accesskeys.extra.hlp
@@ -1,0 +1,5 @@
+{htxt id="accesskeys"}
+  <ul class="crmAccessKeyList">
+    <li><span></span> - {ts}Open/close Recent items, on far right{/ts}</li>
+  </ul>
+{/htxt}


### PR DESCRIPTION
See readme.

This is something that our users really wanted, because they used to refer to the recent items sidebar before we switched from Drupal to Standalone. Their use case is viewing recent items to check spelling or remind themselves of the name, without wanting to actually open the contact.

If this is potentially useful to others, then great if we want to merge it in here. Otherwise, equally happy just to handle it locally and close this.

<img width="1719" height="948" alt="image" src="https://github.com/user-attachments/assets/618bf0eb-5509-4821-ac2f-5a0f3864c7b3" />

Arrows point to the right, but the submenus do open correctly on the left. Does not take focus so the user can continue typing wherever they may be typing. Adds the key combination to the accesskeys help that is found on the bottom of every page. Chose `'` as it doesn't seem to be used for anything in any browsers and is easy to press with the keys close together.